### PR TITLE
Upgrade to React 16 and add prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/zeroseven/react-screen-orientation#readme",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0-rc.1",
-    "webpack": "^1.12.2"
+    "react": "^16.0.0",
+    "webpack": "^4.1.1"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
@@ -33,5 +33,8 @@
     "babel-preset-es2015": "^6.0.15",
     "babel-preset-react": "^6.0.15",
     "standard": "^6.0.8"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { Children, Component, PropTypes } from 'react'
+import React, { Children, Component } from 'react'
+import PropTypes from 'prop-types'
 
 export class Orientation extends Component {
   render () {


### PR DESCRIPTION
Since React **`15.5`**, [`PropTypes`](https://reactjs.org/docs/typechecking-with-proptypes.html) has moved into its own package. Let's upgrade to the latest React and add the separate dependency. No other changes are required to support React `16.0`.

This fixes https://github.com/zeroseven/react-screen-orientation/issues/7.