### PR TITLE
Moved place where lockOrientationUniversal is set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -69,12 +69,11 @@ var noop = function noop() {
   return false;
 };
 
-window.screen.lockOrientationUniversal = window.screen.lockOrientation || window.screen.mozLockOrientation || window.screen.msLockOrientation;
 
 var lock = function lock(orientation) {
   var _window = window,
       screen = _window.screen;
-
+  window.screen.lockOrientationUniversal = window.screen.lockOrientation || window.screen.mozLockOrientation || window.screen.msLockOrientation;
   if (screen.orientation && typeof screen.orientation.lock === 'function') {
     return window.screen.orientation.lock(orientation);
   } else if (screen.lockOrientationUniversal) {


### PR DESCRIPTION
Had an issue where using SSR would return undefined window object when first running, this prevents it