### PR TITLE
React unsafe rename

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -112,8 +112,8 @@ var DeviceOrientation = function (_Component2) {
   }
 
   _createClass(DeviceOrientation, [{
-    key: 'componentWillMount',
-    value: function componentWillMount() {
+    key: 'UNSAFE_componentWillMount',
+    value: function UNSAFE_componentWillMount() {
       this.onOrientationChange(null);
     }
   }, {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/zeroseven/react-screen-orientation#readme",
   "peerDependencies": {
     "prop-types": "^15.6.1",
-    "react": "^16.0.0"
+    "react": "^16.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",

--- a/src/index.js
+++ b/src/index.js
@@ -61,7 +61,7 @@ export default class DeviceOrientation extends Component {
     }
   }
 
-  componentWillMount () {
+  UNSAFE_componentWillMount () {
     this.onOrientationChange(null)
   }
 


### PR DESCRIPTION
This method is generating a warning in the console. Using the alias introduced in React 16.3 will stop it.